### PR TITLE
fixed custom author name and revised messages state

### DIFF
--- a/public_html/src/actions.js
+++ b/public_html/src/actions.js
@@ -4,7 +4,7 @@ module.exports = {
 	*	Parameters: String text. The message that shall be added.
 	*				String author. The name of the author.
 	*/
-	addmessage: function(text, author){
+	addmessage: function(text,author){
 		var date = new Date();
 		var year = date.getFullYear().toString();
 		year = year[2] + year[3];
@@ -32,8 +32,7 @@ module.exports = {
 		var hyphen = "-";
 		time =  hours + ":" + minutes  + " " + day + "/" + month + hyphen + year;
 		
-		params = [text,time,author]
-        return {type: 'MESSAGE_ADD', params};
+        return {type: 'MESSAGE_ADD', text:text,time:time,author:author};
     },
 	changeSettings: function(username) {
 		return {type: 'SETTINGS_CHANGE', author: username};

--- a/public_html/src/components/messageList.js
+++ b/public_html/src/components/messageList.js
@@ -7,16 +7,22 @@ var React = require('react'),
 */
 var MessageList = React.createClass({
     propTypes: {
-		onAddClick: ptypes.func.isRequired
+		onAddClick: ptypes.func.isRequired,
+		author: ptypes.string.isRequired,
+		messages: ptypes.arrayOf(ptypes.shape({
+			text: ptypes.string.isRequired,
+			author: ptypes.string.isRequired,
+			time: ptypes.string.isRequired
+		})).isRequired
     },
 	// Handle the add button when clicked
 	handleClick(e) {
 		// collect the text from the text input
 		var node = this.refs.input;
 		var text = node.value.trim();
-		var author = "Anonymous";
+		var author = this.props.author;
 		// Send the text to the onAddClick function that adds it to the list		
-		this.props.onAddClick(text, author);
+		this.props.onAddClick(text,author);
 		// Reset the input field
 		node.value = '';
 	},
@@ -28,19 +34,20 @@ var MessageList = React.createClass({
 			<h2>Message</h2>
 			</div>
             <div id = 'messagelist'>
+
 				<div id = 'authors'>
-					{this.props.author.map(function (author) {
-					  return (<p id='author'>{author}</p>);
+					{this.props.messages.map(function (msg,n) {
+					  return (<p key={n} id='author'>{msg.author}</p>);
 					})}
 				</div>
 				<div id = 'messages'>
-					{this.props.body.map(function (message) {
-					  return (<p id='message'>{message}</p>);
+					{this.props.messages.map(function (msg,n) {
+					  return (<p key={n} id='message'>{msg.text}</p>);
 					})}
 				</div>
 				<div id = 'times'>
-					{this.props.time.map(function (time) {
-					  return (<p id ='time'>{time}</p>);
+					{this.props.messages.map(function (msg,n) {
+					  return (<p key={n} id ='time'>{msg.time}</p>);
 					})}
 				</div>
             </div>
@@ -58,13 +65,16 @@ var MessageList = React.createClass({
 });
 // Transform the message state to props
 var mapStateToProps = function(state){
-    return state.message;
+    return {
+    	author: state.settings.author,
+    	messages: state.messages
+    };
 };
 // Connect onAddClick function to the messagelistreducer
 var mapDispatchToProps = function(dispatch){
     return {
-		onAddClick: function(text, author){
-            dispatch(actions.addmessage(text, author));
+		onAddClick: function(text,author){
+            dispatch(actions.addmessage(text,author));
         }
     }
 };

--- a/public_html/src/initial-state.js
+++ b/public_html/src/initial-state.js
@@ -1,15 +1,16 @@
 
-var messages = ["hello","world"];	// the initial object
-var times = ["16:00 04/10-15", "16:59 04/11-15"];
-var authors = ["Daniel", "David"];
 // Initialize the states
 module.exports = function(){
     return {
-        message: {
-            body: messages,
-			time: times,
-			author: authors
-        },
+        messages: [{
+			text: "Hello",
+			time: "16:00 04/10-15",
+			author: "Daniel"
+		},{
+			text: "World",
+			time: "16:59 04/11-15",
+			author: "David"
+		}],
 		settings: {
 			author: "Anonymous"
 		}

--- a/public_html/src/reducers/messagelistreducer.js
+++ b/public_html/src/reducers/messagelistreducer.js
@@ -1,21 +1,18 @@
 var initialState = require('./../initial-state');
 
 var MessagelistReducer = function(state, action){
-    var newState = Object.assign({}, state);
+    var newState = [].concat(state);
     switch(action.type){
 		// When you want to add a message
         case 'MESSAGE_ADD':
-			// The message that should be added
-			var message = action.params[0];
-			var time = action.params[1];
-			var author = action.params[2];
-			// Concat the new message, time and author to the list
-            newState.body = newState.body.concat(message);
-			newState.time = newState.time.concat(time);
-			newState.author = newState.author.concat(author);
-            return newState;
+			// Concat the new message
+            return newState.concat({
+            	text: action.text,
+            	time: action.time,
+            	author: action.author
+            });
         default:
-            return state || initialState().message;
+            return state || initialState().messages;
     }
 };
 

--- a/public_html/src/store.js
+++ b/public_html/src/store.js
@@ -4,7 +4,7 @@ var Redux = require('redux'),
     initialState = require('./initial-state');
 // Combine the reducers
 var reducers = Redux.combineReducers({
-    message: messagelistReducer,
+    messages: messagelistReducer,
 	settings: settingsReducer
 });
 


### PR DESCRIPTION
This PR does two things:
-    Fixes so that the author name in settings is used in new messages
-    Changes store state so that messages are stored as objects in one single array instead of having separate arrays for texts, times and authors
